### PR TITLE
Refactor to Guzzle Promises for async operationsFeature/async client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Here's how to fetch and display all currently active alerts:
 
 ```php
 try {
-    $alerts = $client->getActiveAlertsAsync(false)->wait();
+    $alerts = $client->getActiveAlertsAsync()->wait();
 
     echo 'Active alerts: ' . count($alerts->getAllAlerts()) . "\n";
 
@@ -57,7 +57,7 @@ To retrieve historical alert data for a specific region:
 
 ```php
 try {
-    $history = $client->getAlertsHistoryAsync('Харківська область', 'month_ago', false)->wait();
+    $history = $client->getAlertsHistoryAsync('Харківська область', 'month_ago')->wait();
 
     echo "\nAlerts history for Kharkiv Oblast: " . count($history->getAllAlerts()) . "\n";
 
@@ -76,7 +76,7 @@ To check the current status of air raid alerts across all oblasts:
 
 ```php
 try {
-    $statuses = $client->getAirRaidAlertStatusesByOblastAsync(false, false)->wait();
+    $statuses = $client->getAirRaidAlertStatusesByOblastAsync()->wait();
 
     echo "\nAir raid alert statuses by oblast:\n";
 
@@ -94,7 +94,7 @@ The library provides convenient methods to filter alerts by type and location:
 
 ```php
 try {
-    $alerts = $client->getActiveAlertsAsync(false)->wait();
+    $alerts = $client->getActiveAlertsAsync()->wait();
 
     // Get only air raid alerts
     $air_raid_alerts = $alerts->getAirRaidAlerts();
@@ -125,8 +125,8 @@ You can start multiple requests and handle them all together without blocking:
 use GuzzleHttp\Promise\Utils;
 
 $promises = [
-    'active' => $client->getActiveAlertsAsync(false),
-    'history' => $client->getAlertsHistoryAsync('Харківська область', 'month_ago', false),
+    'active' => $client->getActiveAlertsAsync(),
+    'history' => $client->getAlertsHistoryAsync('Харківська область', 'month_ago'),
 ];
 
 Utils::all($promises)->then(function ($results) {
@@ -152,8 +152,8 @@ You can also query multiple oblasts or summary data at the same time:
 
 ```php
 $promises = [
-    'kyiv_status' => $client->getAirRaidAlertStatusAsync('Київська область', true, false),
-    'all_statuses' => $client->getAirRaidAlertStatusesByOblastAsync(false, false),
+    'kyiv_status' => $client->getAirRaidAlertStatusAsync('Київська область', true),
+    'all_statuses' => $client->getAirRaidAlertStatusesByOblastAsync(),
 ];
 
 Utils::all($promises)->then(function ($results) {
@@ -174,7 +174,7 @@ Utils::all($promises)->then(function ($results) {
 You can apply filters to the alerts once they are asynchronously retrieved:
 
 ```php
-$client->getActiveAlertsAsync(false)->then(function ($alerts) {
+$client->getActiveAlertsAsync()->then(function ($alerts) {
     $air_raid_alerts = $alerts->getAirRaidAlerts();
     $oblast_alerts = $alerts->getOblastAlerts();
     $kharkiv_alerts = $alerts->getAlertsByOblast('Харківська область');
@@ -194,40 +194,40 @@ You can continue to use individual `->wait()` calls when needed, but using `Util
 
 ### AlertsClient
 
-#### `getActiveAlertsAsync(bool $use_cache = true): Promise<Alerts>`
+#### `getActiveAlertsAsync(bool $use_cache = false): Promise<Alerts>`
 
 Fetches a list of active alerts asynchronously.
 
-- `$use_cache` – Whether to use cached data (default `true`).
+- `$use_cache` – Whether to use cached data (default `false`).
 
 ---
 
-#### `getAlertsHistoryAsync(string|int $oblast_uid_or_location_title, string $period = 'week_ago', bool $use_cache = true): Promise<Alerts>`
+#### `getAlertsHistoryAsync(string|int $oblast_uid_or_location_title, string $period = 'week_ago', bool $use_cache = false): Promise<Alerts>`
 
 Fetches the alert history for a specific oblast or location.
 
 - `$oblast_uid_or_location_title` – Oblast title or numeric UID.
 - `$period` – Time period to retrieve alerts (e.g. `'month_ago'`, `'week_ago'`).
-- `$use_cache` – Whether to use cached data (default `true`).
+- `$use_cache` – Whether to use cached data (default `false`).
 
 ---
 
-#### `getAirRaidAlertStatusAsync(string|int $oblast_uid_or_location_title, bool $oblast_level_only = false, bool $use_cache = true): Promise<AirRaidAlertOblastStatus>`
+#### `getAirRaidAlertStatusAsync(string|int $oblast_uid_or_location_title, bool $oblast_level_only = false, bool $use_cache = false): Promise<AirRaidAlertOblastStatus>`
 
 Returns air raid alert status for one oblast.
 
 - `$oblast_uid_or_location_title` – Oblast title or UID.
 - `$oblast_level_only` – Only oblast-level alerts (default `false`).
-- `$use_cache` – Use cache (default `true`).
+- `$use_cache` – Use cache (default `false`).
 
 ---
 
-#### `getAirRaidAlertStatusesByOblastAsync(bool $oblast_level_only = false, bool $use_cache = true): Promise<AirRaidAlertOblastStatuses>`
+#### `getAirRaidAlertStatusesByOblastAsync(bool $oblast_level_only = false, bool $use_cache = false): Promise<AirRaidAlertOblastStatuses>`
 
 Returns air raid alert statuses across all oblasts.
 
 - `$oblast_level_only` – Only oblast-level alerts (default `false`).
-- `$use_cache` – Use cache (default `true`).
+- `$use_cache` – Use cache (default `false`).
 
 ---
 

--- a/src/Cache/ExpirableCacheInterface.php
+++ b/src/Cache/ExpirableCacheInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Fyennyi\AlertsInUa\Cache;
+
+/**
+ * Interface for cache storage with support for expiring keys
+ */
+interface ExpirableCacheInterface extends CacheInterface
+{
+    /**
+     * Clean up expired keys if supported by the implementation
+     */
+    public function cleanupExpired() : void;
+}

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -5,7 +5,7 @@ namespace Fyennyi\AlertsInUa\Cache;
 /**
  * File-based persistent cache implementation
  */
-class FileCache implements CacheInterface
+class FileCache implements ExpirableCacheInterface
 {
     private string $cache_dir;
 
@@ -35,8 +35,6 @@ class FileCache implements CacheInterface
         }
 
         if ($item['expires'] > 0 && $item['expires'] < time()) {
-            unlink($filename);
-
             return null;
         }
 
@@ -136,5 +134,32 @@ class FileCache implements CacheInterface
     private function getCacheFilename(string $key) : string
     {
         return $this->cache_dir . '/' . md5($key) . '.cache';
+    }
+
+    public function cleanupExpired() : void
+    {
+        $files = glob($this->cache_dir . '/*.cache');
+
+        if (false === $files) {
+            return;
+        }
+
+        $now = time();
+
+        foreach ($files as $file) {
+            $data = @file_get_contents($file);
+            if (false === $data) {
+                continue;
+            }
+
+            $item = @unserialize($data);
+            if (! is_array($item) || ! isset($item['expires'])) {
+                continue;
+            }
+
+            if ($item['expires'] > 0 && $item['expires'] < $now) {
+                @unlink($file);
+            }
+        }
     }
 }

--- a/src/Cache/InMemoryCache.php
+++ b/src/Cache/InMemoryCache.php
@@ -5,7 +5,7 @@ namespace Fyennyi\AlertsInUa\Cache;
 /**
  * Simple in-memory cache implementation
  */
-class InMemoryCache implements CacheInterface
+class InMemoryCache implements ExpirableCacheInterface
 {
     /** @var array<string, array{value: mixed, expires: int}> */
     private array $cache = [];
@@ -19,8 +19,6 @@ class InMemoryCache implements CacheInterface
         $item = $this->cache[$key];
 
         if ($item['expires'] > 0 && $item['expires'] < time()) {
-            unset($this->cache[$key]);
-
             return null;
         }
 
@@ -64,5 +62,15 @@ class InMemoryCache implements CacheInterface
     public function keys() : array
     {
         return array_keys($this->cache);
+    }
+
+    public function cleanupExpired() : void
+    {
+        $now = time();
+        foreach ($this->cache as $key => $item) {
+            if ($item['expires'] > 0 && $item['expires'] < $now) {
+                unset($this->cache[$key]);
+            }
+        }
     }
 }

--- a/src/Cache/SmartCacheManager.php
+++ b/src/Cache/SmartCacheManager.php
@@ -21,7 +21,7 @@ class SmartCacheManager
     /** @var array<string, int> Last request time by cache key */
     private array $last_request_time = [];
 
-    public function __construct(CacheInterface $cache = null)
+    public function __construct(?CacheInterface $cache = null)
     {
         $this->cache = $cache ?? new InMemoryCache();
     }
@@ -57,6 +57,10 @@ class SmartCacheManager
 
         $data = $callback();
         $ttl = $this->ttl_config[$type] ?? 300;
+
+        if ($this->cache instanceof ExpirableCacheInterface) {
+            $this->cache->cleanupExpired();
+        }
 
         $this->cache->set($key, $data, $ttl);
         $this->last_request_time[$key] = time();

--- a/src/Client/AlertsClient.php
+++ b/src/Client/AlertsClient.php
@@ -43,7 +43,7 @@ class AlertsClient
      * @param  string  $token  API token
      * @param  CacheInterface|null  $cache  Optional cache implementation
      */
-    public function __construct(string $token, CacheInterface $cache = null)
+    public function __construct(string $token, ?CacheInterface $cache = null)
     {
         $this->client = new Client;
         $this->token = $token;

--- a/src/Client/AlertsClient.php
+++ b/src/Client/AlertsClient.php
@@ -56,7 +56,7 @@ class AlertsClient
      * @param  bool  $use_cache  Whether to use cached results if available
      * @return PromiseInterface Promise that resolves to an Alerts object
      */
-    public function getActiveAlertsAsync(bool $use_cache = true) : PromiseInterface
+    public function getActiveAlertsAsync(bool $use_cache = false) : PromiseInterface
     {
         return $this->createAsync('alerts/active.json', $use_cache, fn ($data) => new Alerts($data), 'active_alerts');
     }
@@ -71,7 +71,7 @@ class AlertsClient
      *
      * @throws InvalidParameterException If the location cannot be resolved
      */
-    public function getAlertsHistoryAsync(string|int $oblast_uid_or_location_title, string $period = 'week_ago', bool $use_cache = true) : PromiseInterface
+    public function getAlertsHistoryAsync(string|int $oblast_uid_or_location_title, string $period = 'week_ago', bool $use_cache = false) : PromiseInterface
     {
         $oblast_uid = $this->resolveUid($oblast_uid_or_location_title);
         $url = "regions/{$oblast_uid}/alerts/{$period}.json";
@@ -89,7 +89,7 @@ class AlertsClient
      *
      * @throws InvalidParameterException If the location cannot be resolved
      */
-    public function getAirRaidAlertStatusAsync(string|int $oblast_uid_or_location_title, bool $oblast_level_only = false, bool $use_cache = true) : PromiseInterface
+    public function getAirRaidAlertStatusAsync(string|int $oblast_uid_or_location_title, bool $oblast_level_only = false, bool $use_cache = false) : PromiseInterface
     {
         $oblast_uid = $this->resolveUid($oblast_uid_or_location_title);
         $url = "iot/active_air_raid_alerts/{$oblast_uid}.json";
@@ -120,7 +120,7 @@ class AlertsClient
      * @param  bool  $use_cache  Whether to use cached results if available
      * @return PromiseInterface Promise that resolves to an AirRaidAlertOblastStatuses object
      */
-    public function getAirRaidAlertStatusesByOblastAsync(bool $oblast_level_only = false, bool $use_cache = true) : PromiseInterface
+    public function getAirRaidAlertStatusesByOblastAsync(bool $oblast_level_only = false, bool $use_cache = false) : PromiseInterface
     {
         return $this->createAsync(
             'iot/active_air_raid_alerts_by_oblast.json',

--- a/src/Util/UserAgent.php
+++ b/src/Util/UserAgent.php
@@ -4,7 +4,7 @@ namespace Fyennyi\AlertsInUa\Util;
 
 class UserAgent
 {
-    private const DEFAULT_AGENT = 'aiu-php-client/1.0 (+https://alerts.in.ua)';
+    private const DEFAULT_AGENT = 'alerts-in-ua-php/0.2.5 (+https://github.com/Fyennyi/alerts-in-ua-php)';
 
     /**
      * Get User-Agent string for API requests

--- a/tests/Integration/AlertsClientTest.php
+++ b/tests/Integration/AlertsClientTest.php
@@ -85,13 +85,13 @@ class AlertsClientTest extends TestCase
         ])));
 
         // Call method with location title
-        $result = $this->alertsClient->getAlertsHistoryAsync('Харківська область', 'month_ago')->wait();
+        $result = $this->alertsClient->getAlertsHistoryAsync('Харківська область')->wait();
 
         // Assert request was made correctly
         $this->assertCount(1, $this->historyContainer);
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', $request->getMethod());
-        $this->assertEquals('/v1/regions/22/alerts/day_ago.json', $request->getUri()->getPath());
+        $this->assertEquals('/v1/regions/22/alerts/week_ago.json', $request->getUri()->getPath());
 
         // Assert response was parsed correctly
         $this->assertInstanceOf(Alerts::class, $result);

--- a/tests/Integration/AlertsClientTest.php
+++ b/tests/Integration/AlertsClientTest.php
@@ -56,7 +56,7 @@ class AlertsClientTest extends TestCase
         ])));
 
         // Call method
-        $result = $this->alertsClient->getActiveAlertsAsync(false)->wait();
+        $result = $this->alertsClient->getActiveAlertsAsync()->wait();
 
         // Assert request was made correctly
         $this->assertCount(1, $this->historyContainer);
@@ -85,7 +85,7 @@ class AlertsClientTest extends TestCase
         ])));
 
         // Call method with location title
-        $result = $this->alertsClient->getAlertsHistoryAsync('Харківська область', 'day_ago', false)->wait();
+        $result = $this->alertsClient->getAlertsHistoryAsync('Харківська область', 'month_ago')->wait();
 
         // Assert request was made correctly
         $this->assertCount(1, $this->historyContainer);
@@ -181,7 +181,7 @@ class AlertsClientTest extends TestCase
         $this->expectException(\Fyennyi\AlertsInUa\Exception\UnauthorizedError::class);
 
         // Call method
-        $this->alertsClient->getActiveAlertsAsync(false)->wait(); // Here the UnauthorizedError will be thrown and the test will pass
+        $this->alertsClient->getActiveAlertsAsync()->wait(); // Here the UnauthorizedError will be thrown and the test will pass
     }
 
     public function testCache()

--- a/tests/Integration/ApiIntegrationTest.php
+++ b/tests/Integration/ApiIntegrationTest.php
@@ -36,7 +36,7 @@ class ApiIntegrationTest extends TestCase
         $this->mockHandler->append(new Response(200, [], $alertsResponseJson));
 
         $alertsClient = $this->createMockAlertsClient();
-        $alerts = $alertsClient->getActiveAlertsAsync(false)->wait();
+        $alerts = $alertsClient->getActiveAlertsAsync()->wait();
 
         // Analyze alerts
         $this->assertGreaterThan(0, count($alerts->getAllAlerts()));
@@ -47,7 +47,7 @@ class ApiIntegrationTest extends TestCase
         $historyResponseJson = file_get_contents(__DIR__ . '/../fixtures/alerts_history.json');
         $this->mockHandler->append(new Response(200, [], $historyResponseJson));
 
-        $history = $alertsClient->getAlertsHistoryAsync('Харківська область', 'week_ago', false)->wait();
+        $history = $alertsClient->getAlertsHistoryAsync('Харківська область', 'week_ago')->wait();
 
         // Check history
         $this->assertGreaterThan(0, count($history->getAllAlerts()));


### PR DESCRIPTION
This pull request replaces the previous PHP Fiber-based async implementation with native Guzzle Promises to improve compatibility, readability, and performance.

### Major Changes

- **Async Refactor:** All public async methods now return `PromiseInterface` from Guzzle, removing the need for Fibers.
- **Removed internal logic:** Legacy `createFiber()`, `$fibers`, `$promises`, and the `wait()` method have been removed.
- **New Alert utility methods:**
  - `getDuration()` (returns `DateInterval`)
  - `getDurationInSeconds()`
  - `toArray()`
  - `toJson()`

### Additional Improvements

- Updated default `$use_cache` value to `false`, requiring explicit opt-in.
- Updated integration tests to use Guzzle Promises and assert async results.
- Updated User-Agent string to reflect version 0.2.5.