### PR TITLE
Implement JsonSerializable and PHPDoc Fix

### DIFF
--- a/src/Model/AirRaidAlertOblastStatuses.php
+++ b/src/Model/AirRaidAlertOblastStatuses.php
@@ -26,11 +26,12 @@ namespace Fyennyi\AlertsInUa\Model;
 
 use Countable;
 use IteratorAggregate;
+use JsonSerializable;
 
 /**
  * @implements IteratorAggregate<int, AirRaidAlertOblastStatus>
  */
-class AirRaidAlertOblastStatuses implements IteratorAggregate, Countable
+class AirRaidAlertOblastStatuses implements Countable, IteratorAggregate, JsonSerializable
 {
     /** @var list<AirRaidAlertOblastStatus> */
     private array $statuses;
@@ -128,6 +129,14 @@ class AirRaidAlertOblastStatuses implements IteratorAggregate, Countable
     public function count() : int
     {
         return count($this->statuses);
+    }
+
+    /**
+     * @return list<AirRaidAlertOblastStatus>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->statuses;
     }
 
     public function __toString() : string

--- a/src/Model/AirRaidAlertStatus.php
+++ b/src/Model/AirRaidAlertStatus.php
@@ -24,7 +24,9 @@
 
 namespace Fyennyi\AlertsInUa\Model;
 
-class AirRaidAlertStatus
+use JsonSerializable;
+
+class AirRaidAlertStatus implements JsonSerializable
 {
     private string $location_title;
 
@@ -74,5 +76,17 @@ class AirRaidAlertStatus
     public function getUid() : ?int
     {
         return $this->uid;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize() : array
+    {
+        return [
+            'location_title' => $this->location_title,
+            'status' => $this->status,
+            'uid' => $this->uid,
+        ];
     }
 }

--- a/src/Model/AirRaidAlertStatuses.php
+++ b/src/Model/AirRaidAlertStatuses.php
@@ -27,13 +27,14 @@ namespace Fyennyi\AlertsInUa\Model;
 use ArrayAccess;
 use Countable;
 use IteratorAggregate;
+use JsonSerializable;
 use Traversable;
 
 /**
  * @implements IteratorAggregate<int, AirRaidAlertStatus>
  * @implements ArrayAccess<int, AirRaidAlertStatus>
  */
-class AirRaidAlertStatuses implements IteratorAggregate, Countable, ArrayAccess
+class AirRaidAlertStatuses implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
 {
     /** @var array<int, AirRaidAlertStatus> */
     private array $statuses;
@@ -136,5 +137,15 @@ class AirRaidAlertStatuses implements IteratorAggregate, Countable, ArrayAccess
     public function offsetUnset($offset) : void
     {
         // This is a read-only collection
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     *
+     * @return array<int, AirRaidAlertStatus> The array of statuses to be serialized
+     */
+    public function jsonSerialize() : array
+    {
+        return $this->statuses;
     }
 }

--- a/src/Model/Alert.php
+++ b/src/Model/Alert.php
@@ -27,8 +27,9 @@ namespace Fyennyi\AlertsInUa\Model;
 use DateInterval;
 use DateTimeImmutable;
 use Fyennyi\AlertsInUa\Util\UaDateParser;
+use JsonSerializable;
 
-class Alert implements \JsonSerializable
+class Alert implements JsonSerializable
 {
     private int $id;
 

--- a/src/Model/Alerts.php
+++ b/src/Model/Alerts.php
@@ -34,7 +34,7 @@ use JsonSerializable;
 /**
  * @implements IteratorAggregate<int, Alert>
  */
-class Alerts implements IteratorAggregate, Countable, JsonSerializable
+class Alerts implements Countable, IteratorAggregate, JsonSerializable
 {
     /** @var list<Alert> */
     private array $alerts;
@@ -333,6 +333,11 @@ class Alerts implements IteratorAggregate, Countable, JsonSerializable
      */
     public function __toString() : string
     {
-        return json_encode($this, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        try {
+            return json_encode($this, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            error_log('Failed to serialize Alerts to string: ' . $e->getMessage());
+            return '';
+        }
     }
 }

--- a/src/Model/Alerts.php
+++ b/src/Model/Alerts.php
@@ -46,7 +46,7 @@ class Alerts implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Constructor for Alerts collection
      *
-     * @param  array<mixed, mixed>  $data  Raw alerts data from API
+     * @param  array<string|int, mixed>  $data  Raw alerts data from API
      */
     public function __construct(array $data)
     {

--- a/tests/Unit/AirRaidAlertOblastStatusesTest.php
+++ b/tests/Unit/AirRaidAlertOblastStatusesTest.php
@@ -60,6 +60,20 @@ class AirRaidAlertOblastStatusesTest extends TestCase
         $this->assertJsonStringEqualsJsonString($expectedJson, (string) $statuses);
     }
 
+    public function testJsonSerialize(): void
+    {
+        $data = 'ANP';
+        $statuses = new AirRaidAlertOblastStatuses($data, false);
+
+        $expectedJson = json_encode([
+            ['oblast' => 'Автономна Республіка Крим', 'status' => 'active'],
+            ['oblast' => 'Волинська область', 'status' => 'no_alert'],
+            ['oblast' => 'Вінницька область', 'status' => 'partly'],
+        ]);
+
+        $this->assertJsonStringEqualsJsonString($expectedJson, json_encode($statuses));
+    }
+
     public function testGetIterator()
     {
         $data = 'ANP';

--- a/tests/Unit/AirRaidAlertStatusTest.php
+++ b/tests/Unit/AirRaidAlertStatusTest.php
@@ -31,4 +31,17 @@ class AirRaidAlertStatusTest extends TestCase
         $this->assertEquals($status, $airRaidAlertStatus->getStatus());
         $this->assertNull($airRaidAlertStatus->getUid());
     }
+
+    public function testJsonSerialize(): void
+    {
+        $status = new AirRaidAlertStatus('Test Location', 'active', 123);
+        $expected = [
+            'location_title' => 'Test Location',
+            'status' => 'active',
+            'uid' => 123,
+        ];
+
+        $this->assertEquals($expected, $status->jsonSerialize());
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($status));
+    }
 }

--- a/tests/Unit/AirRaidAlertStatusesTest.php
+++ b/tests/Unit/AirRaidAlertStatusesTest.php
@@ -182,4 +182,27 @@ class AirRaidAlertStatusesTest extends TestCase
         $this->assertCount(1, $airRaidAlertStatuses);
         $this->assertEquals($status1, $airRaidAlertStatuses[0]);
     }
+
+    public function testJsonSerialize(): void
+    {
+        $status1 = new AirRaidAlertStatus('Київська область', 'active', 1);
+        $status2 = new AirRaidAlertStatus('Львівська область', 'no_alert', 2);
+        $statuses = [$status1, $status2];
+        $airRaidAlertStatuses = new AirRaidAlertStatuses($statuses);
+
+        $expectedJson = json_encode([
+            [
+                'location_title' => 'Київська область',
+                'status' => 'active',
+                'uid' => 1,
+            ],
+            [
+                'location_title' => 'Львівська область',
+                'status' => 'no_alert',
+                'uid' => 2,
+            ],
+        ]);
+
+        $this->assertJsonStringEqualsJsonString($expectedJson, json_encode($airRaidAlertStatuses));
+    }
 }

--- a/tests/Unit/AlertsTest.php
+++ b/tests/Unit/AlertsTest.php
@@ -218,4 +218,27 @@ class AlertsTest extends TestCase
         $this->assertStringContainsString('Харківська область', $string);
         $this->assertStringContainsString('Test disclaimer', $string);
     }
+
+    public function testToStringReturnsEmptyStringOnJsonFailure(): void
+    {
+        // Create a mock Alert with invalid UTF-8 characters in a string property
+        $invalidUtf8Data = [
+            'alerts' => [
+                ['location_title' => "\xB1\x31"] // Invalid UTF-8 sequence
+            ]
+        ];
+        $alerts = new Alerts($invalidUtf8Data);
+
+        // Temporarily suppress error log output for this test
+        $originalErrorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+
+        try {
+            // The __toString method should catch the JsonException and return an empty string
+            $this->assertEquals('', (string)$alerts);
+        } finally {
+            // Restore the original error log setting
+            ini_set('error_log', $originalErrorLog);
+        }
+    }
 }

--- a/tests/Unit/Cache/SmartCacheManagerTest.php
+++ b/tests/Unit/Cache/SmartCacheManagerTest.php
@@ -33,7 +33,7 @@ class SmartCacheManagerTest extends TestCase
 
         $this->cacheMock->expects($this->once())
             ->method('get')
-            ->with('test_key', $this->isType('callable'))
+            ->with('test_key', $this->isCallable())
             ->willReturn('cached_data');
 
         $result = $this->manager->getOrSet('test_key', $callback);
@@ -48,7 +48,7 @@ class SmartCacheManagerTest extends TestCase
         // 1. First 'get' call to check the cache (miss)
         $this->cacheMock->expects($this->atLeastOnce())
             ->method('get')
-            ->with('test_key', $this->isType('callable'))
+            ->with('test_key', $this->isCallable())
             ->willReturn(null);
 
         $result = $this->manager->getOrSet('test_key', $callback, 'custom_type');
@@ -82,7 +82,7 @@ class SmartCacheManagerTest extends TestCase
         $this->cacheMock->expects($this->once())->method('delete')->with('key.last_modified');
         $this->cacheMock->expects($this->once())
             ->method('get')
-            ->with('key.last_modified', $this->isType('callable'))
+            ->with('key.last_modified', $this->isCallable())
             ->willReturnCallback(
                 function ($key, $callable) {
                     $itemMock = $this->createMock(ItemInterface::class);
@@ -99,7 +99,7 @@ class SmartCacheManagerTest extends TestCase
     {
         $this->cacheMock->expects($this->once())
             ->method('get')
-            ->with('key.last_modified', $this->isType('callable'))
+            ->with('key.last_modified', $this->isCallable())
             ->willReturn('timestamp');
 
         $this->assertEquals('timestamp', $this->manager->getLastModified('key'));
@@ -111,7 +111,7 @@ class SmartCacheManagerTest extends TestCase
         $this->cacheMock->expects($this->once())->method('delete')->with('key.processed');
         $this->cacheMock->expects($this->once())
             ->method('get')
-            ->with('key.processed', $this->isType('callable'))
+            ->with('key.processed', $this->isCallable())
              ->willReturnCallback(
                 function ($key, $callable) {
                     $itemMock = $this->createMock(ItemInterface::class);
@@ -129,7 +129,7 @@ class SmartCacheManagerTest extends TestCase
         $data = ['a' => 1];
         $this->cacheMock->expects($this->once())
             ->method('get')
-            ->with('key.processed', $this->isType('callable'))
+            ->with('key.processed', $this->isCallable())
             ->willReturn($data);
 
         $this->assertEquals($data, $this->manager->getCachedData('key'));


### PR DESCRIPTION
This Pull Request introduces the implementation of the `JsonSerializable` interface and includes a fix for a PHPDoc array type.

### Key Changes

1. **Implement JsonSerializable:**
   - The `JsonSerializable` interface has been implemented, and the test suite has been improved.

2. **PHPDoc Fix:**
   - Corrected the array type in `Alerts.php` PHPDoc from `array<mixed, mixed>` to `array<string|int, mixed>` to adhere to PHPStan/PHPDoc standards.