### PR TITLE
Add Stand With Ukraine banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # API Client for alerts.in.ua in PHP
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://stand-with-ukraine.pp.ua)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/fyennyi/alerts-in-ua-php.svg?label=Packagist&logo=packagist)](https://packagist.org/packages/fyennyi/alerts-in-ua-php)
 [![Total Downloads](https://img.shields.io/packagist/dt/fyennyi/alerts-in-ua-php.svg?label=Downloads&logo=packagist)](https://packagist.org/packages/fyennyi/alerts-in-ua-php)
 [![License](https://img.shields.io/packagist/l/fyennyi/alerts-in-ua-php.svg?label=Licence&logo=open-source-initiative)](https://packagist.org/packages/fyennyi/alerts-in-ua-php)


### PR DESCRIPTION
This pull request adds the **Stand With Ukraine** banner to the top of the project’s README.

### Summary

Added solidarity banner to show support for Ukraine and to align the project with the broader open-source community initiative.

The banner is placed below the main title and before the badges for better visibility and consistency with common usage in other repositories.

### Why this change

The project is directly related to air-raid alerts in Ukraine, so including this banner is contextually appropriate and helps communicate the project's mission and origin.